### PR TITLE
Fix footer display and button formatting

### DIFF
--- a/react-ui/src/components/Footer.jsx
+++ b/react-ui/src/components/Footer.jsx
@@ -7,7 +7,7 @@ import classes from './Footer.module.css';
 
 function Footer() {
   const currentYear = new Date().getFullYear();
-  const buildInfo = process.env.REACT_APP_BUILD_NUMBER || 'dev';
+  const buildInfo = process.env.REACT_APP_BUILD_NUMBER;
   
   return (
     <div className={classes.footer}>
@@ -16,15 +16,15 @@ function Footer() {
           <Text size="sm" c="dimmed">
             © {currentYear} Angus Hally. All rights reserved.
           </Text>
-          {process.env.NODE_ENV === 'production' ? (
-            <Text size="xs" c="dimmed">
-              Build: {buildInfo}
-            </Text>
-          ) : (
+          {process.env.NODE_ENV === 'development' ? (
             <Text size="xs" c="dimmed">
               Development Environment
             </Text>
-          )}
+          ) : buildInfo ? (
+            <Text size="xs" c="dimmed">
+              Build: {buildInfo}
+            </Text>
+          ) : null}
         </div>
         <Group gap={0} className={classes.links} justify="flex-end" wrap="nowrap">
           <ActionIcon 

--- a/react-ui/src/components/Footer.test.jsx
+++ b/react-ui/src/components/Footer.test.jsx
@@ -53,7 +53,7 @@ describe('Footer Component', () => {
     expect(screen.getByText('Development Environment')).toBeInTheDocument();
   });
 
-  test('renders build number in production', () => {
+  test('renders build number in production when build number is provided', () => {
     process.env.NODE_ENV = 'production';
     process.env.REACT_APP_BUILD_NUMBER = 'v1.2.3';
     
@@ -66,7 +66,7 @@ describe('Footer Component', () => {
     expect(screen.getByText('Build: v1.2.3')).toBeInTheDocument();
   });
 
-  test('renders default build info in production when build number is not set', () => {
+  test('renders no build info in production when build number is not set', () => {
     process.env.NODE_ENV = 'production';
     delete process.env.REACT_APP_BUILD_NUMBER;
     
@@ -76,7 +76,9 @@ describe('Footer Component', () => {
       </TestWrapper>
     );
 
-    expect(screen.getByText('Build: dev')).toBeInTheDocument();
+    // Should not show any build information
+    expect(screen.queryByText(/Build:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Development Environment/)).not.toBeInTheDocument();
   });
 
   test('renders all social media links with correct attributes', () => {

--- a/react-ui/src/pages/Home.jsx
+++ b/react-ui/src/pages/Home.jsx
@@ -105,7 +105,7 @@ function Home() {
           </motion.div>
         </motion.div>
       </Container>
-      <Box >
+      <Box ta="center" mb="xl">
         <Button
           component={Link}
           to="/contact"


### PR DESCRIPTION
Correct footer build information display logic and add spacing to the contact button.

The footer previously displayed 'Build: dev' in production environments when `REACT_APP_BUILD_NUMBER` was not set, which was incorrect. This PR updates the logic to show 'Development Environment' in development, 'Build: [number]' in production with a build number, and nothing in production without a build number. Additionally, margin was added to the contact button to prevent it from obscuring the footer on mobile.