### PR TITLE
Improve OpenGraph metadata parsing for varied image formats

### DIFF
--- a/server/tests/testOpenGraph.test.js
+++ b/server/tests/testOpenGraph.test.js
@@ -62,8 +62,8 @@ describe('OpenGraph Service', () => {
         description: null,
         image: null,
         site_name: null,
-        resolved_url: null,
-        error: 'Network error'
+        resolved_url: 'https://example.com',
+        error: { message: 'Network error', code: 'UNKNOWN_ERROR' }
       });
     });
 
@@ -76,7 +76,7 @@ describe('OpenGraph Service', () => {
         image: null,
         site_name: null,
         resolved_url: null,
-        error: 'Invalid URL format'
+        error: { message: 'Invalid URL format', code: 'INVALID_URL' }
       });
     });
 


### PR DESCRIPTION
## Summary
- handle OpenGraph image responses that aren't arrays
- validate URLs before scraping and return structured errors
- adjust OpenGraph tests for new error structure

## Testing
- `cd server && npx jest tests/testOpenGraph.test.js --runInBand`
- `npm test` *(fails: 3 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688fc963b6948333b9433fdac165d689